### PR TITLE
Setup a template slide show with the needed boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,3 +214,15 @@ Week 25 - MongoDB & Mongoose
 **Exercise Tracker**
 
 **File Metadata Microservice**
+
+
+# Setting Up This Repo
+
+```
+git clone --recursive <repository_url>
+```
+If you did not do a recursive clone first
+```
+git submodule init
+git submodule update --init --recursive
+```

--- a/module1/version-control.html
+++ b/module1/version-control.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+		<title>Version Control</title>
+
+		<link rel="stylesheet" href="../reveal.js/dist/reset.css">
+		<link rel="stylesheet" href="../reveal.js/dist/reveal.css">
+		<!-- <link rel="stylesheet" href="../reveal.js/dist/theme/black.css"> -->
+		<link rel="stylesheet" href="../ffccbc.css">
+
+		<!-- Theme used for syntax highlighted code -->
+		<link rel="stylesheet" href="../reveal.js/plugin/highlight/monokai.css">
+	</head>
+	<body>
+		<div class="reveal">
+			<div class="slides">
+				<section>Welcome to the Free freeCodeCamp Bootcamp</section>
+				<section>Version Control</section>
+				<section>Slide 3</section>
+			</div>
+		</div>
+
+		<script src="../reveal.js/dist/reveal.js"></script>
+		<script src="../reveal.js/plugin/notes/notes.js"></script>
+		<script src="../reveal.js/plugin/markdown/markdown.js"></script>
+		<script src="../reveal.js/plugin/highlight/highlight.js"></script>
+		<script>
+			// More info about initialization & config:
+			// - https://revealjs.com/initialization/
+			// - https://revealjs.com/config/
+			Reveal.initialize({
+				hash: true,
+
+				// Learn about plugins: https://revealjs.com/plugins/
+				plugins: [ RevealMarkdown, RevealHighlight, RevealNotes ]
+			});
+		</script>
+	</body>
+</html>

--- a/template.html
+++ b/template.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+		<title>reveal.js</title>
+
+		<link rel="stylesheet" href="reveal.js/dist/reset.css">
+		<link rel="stylesheet" href="reveal.js/dist/reveal.css">
+		<!-- <link rel="stylesheet" href="reveal.js/dist/theme/black.css"> -->
+		<link rel="stylesheet" href="ffccbc.css">
+
+		<!-- Theme used for syntax highlighted code -->
+		<link rel="stylesheet" href="reveal.js/plugin/highlight/monokai.css">
+	</head>
+	<body>
+		<div class="reveal">
+			<div class="slides">
+				<section>Welcome to the Free freeCodeCamp Bootcamp</section>
+				<section>Slide 2</section>
+				<section>Slide 3</section>
+			</div>
+		</div>
+
+		<script src="reveal.js/dist/reveal.js"></script>
+		<script src="reveal.js/plugin/notes/notes.js"></script>
+		<script src="reveal.js/plugin/markdown/markdown.js"></script>
+		<script src="reveal.js/plugin/highlight/highlight.js"></script>
+		<script>
+			// More info about initialization & config:
+			// - https://revealjs.com/initialization/
+			// - https://revealjs.com/config/
+			Reveal.initialize({
+				hash: true,
+
+				// Learn about plugins: https://revealjs.com/plugins/
+				plugins: [ RevealMarkdown, RevealHighlight, RevealNotes ]
+			});
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
In this update, I have made a template.html that has the basic boilerplate we need to add a new slideshow.

We use submodules to pull in the Reveal.js theme, so I also added commands to the README.md for anyone cloning for the first time.